### PR TITLE
Updating hack for Leaflet to fix mobile drag

### DIFF
--- a/src/data/template/static/css/style.css
+++ b/src/data/template/static/css/style.css
@@ -18,6 +18,7 @@ body {
 }
 
 .control-wrapper {
+	cursor: pointer;
 }
 
 .control-wrapper-panel {

--- a/src/data/template/static/css/style.css
+++ b/src/data/template/static/css/style.css
@@ -18,7 +18,6 @@ body {
 }
 
 .control-wrapper {
-	cursor: pointer;
 }
 
 .control-wrapper-panel {

--- a/src/data/template/static/js/mapcrafterui.js
+++ b/src/data/template/static/js/mapcrafterui.js
@@ -383,14 +383,6 @@ MapcrafterUI.prototype.addControl = function(control, position, index) {
 				wrapper.setAttribute("class", "control-wrapper control-wrapper-invisible");
 				wrapper.setAttribute("id", "control-wrapper-" + control.getName());
 			}
-
-			// just a dirty hack to prevent the map getting all mouse click events
-			wrapper.onmouseover = function() {
-				map.dragging.disable();
-			};
-			wrapper.onmouseout = function() {
-				map.dragging.enable();
-			};
 			
 			control.ui = self;
 			control.create(wrapper);

--- a/src/data/template/static/js/mapcrafterui.js
+++ b/src/data/template/static/js/mapcrafterui.js
@@ -383,6 +383,14 @@ MapcrafterUI.prototype.addControl = function(control, position, index) {
 				wrapper.setAttribute("class", "control-wrapper control-wrapper-invisible");
 				wrapper.setAttribute("id", "control-wrapper-" + control.getName());
 			}
+
+			// just a dirty hack to prevent the map getting all mouse click events
+			wrapper.onpointerover = function() {
+				map.dragging.disable();
+			};
+			wrapper.onpointerout = function() {
+				map.dragging.enable();
+			};
 			
 			control.ui = self;
 			control.create(wrapper);


### PR DESCRIPTION
I found a bug for mapcrafter users that is reproducible by:
1. Viewing an isometric map from a mobile device
2. Pan around with a single finger, which works at first
3. Click one of the other map rotations
4. Try to pan around with a single finger, it does not work after rotating the map

After much debugging in Chrome's device emulator, I found a self proclaimed "dirty hack" in mapcrafterui.js that says it is attempting to shield the map from certain click events. Removing this code seems to fix the issue I was experiencing. I clicked all available buttons and toggled markers but did not see any undesired behavior. Let me know if you have any questions. I believe this fix could be applied to any branch that uses Leaflet 1.3.4.

I realize that this hack is intended to stop drag events from initiating on a button press, but I think the harm of this bug outweighs the benefit of the hack. I would like to hear what others think.