### PR TITLE
Cleaned up compiler warnings caused by comparing unsigned ints w/ signed ints

### DIFF
--- a/src/mapcraftercore/renderer/blockimages.cpp
+++ b/src/mapcraftercore/renderer/blockimages.cpp
@@ -110,8 +110,8 @@ void blockImageTest(RGBAImage& block, const RGBAImage& uv_mask) {
 	assert(block.getWidth() == uv_mask.getWidth());
 	assert(block.getHeight() == uv_mask.getHeight());
 	
-	for (size_t x = 0; x < block.getWidth(); x++) {
-		for (size_t y = 0; y < block.getHeight(); y++) {
+	for (int x = 0; x < block.getWidth(); x++) {
+		for (int y = 0; y < block.getHeight(); y++) {
 			uint32_t& pixel = block.pixel(x, y);
 			uint32_t uv_pixel = uv_mask.pixel(x, y);
 			if (rgba_alpha(uv_pixel) == 0) {
@@ -137,8 +137,8 @@ void blockImageMultiply(RGBAImage& block, const RGBAImage& uv_mask,
 	assert(block.getWidth() == uv_mask.getWidth());
 	assert(block.getHeight() == uv_mask.getHeight());
 	
-	for (size_t x = 0; x < block.getWidth(); x++) {
-		for (size_t y = 0; y < block.getHeight(); y++) {
+	for (int x = 0; x < block.getWidth(); x++) {
+		for (int y = 0; y < block.getHeight(); y++) {
 			uint32_t& pixel = block.pixel(x, y);
 			uint32_t uv_pixel = uv_mask.pixel(x, y);
 			if (rgba_alpha(uv_pixel) == 0) {
@@ -164,8 +164,8 @@ void blockImageMultiplyExcept(RGBAImage& block, const RGBAImage& uv_mask,
 	assert(block.getWidth() == uv_mask.getWidth());
 	assert(block.getHeight() == uv_mask.getHeight());
 	
-	for (size_t x = 0; x < block.getWidth(); x++) {
-		for (size_t y = 0; y < block.getHeight(); y++) {
+	for (int x = 0; x < block.getWidth(); x++) {
+		for (int y = 0; y < block.getHeight(); y++) {
 			uint32_t& pixel = block.pixel(x, y);
 			uint32_t uv_pixel = uv_mask.pixel(x, y);
 			if (rgba_alpha(uv_pixel) == 0) {
@@ -209,8 +209,8 @@ void blockImageMultiply(RGBAImage& block, const RGBAImage& uv_mask,
 	}
 
 	
-	size_t n = block.getWidth() * block.getHeight();
-	for (size_t i = 0; i < n; i++) {
+	int n = block.getWidth() * block.getHeight();
+	for (int i = 0; i < n; i++) {
 		uint32_t& pixel = block.data[i];
 		uint32_t uv_pixel = uv_mask.data[i];
 		if (rgba_alpha(uv_pixel) == 0) {
@@ -298,8 +298,8 @@ void blockImageMultiply(RGBAImage& block, const RGBAImage& uv_mask,
 }
 
 void blockImageMultiply(RGBAImage& block, uint8_t factor) {
-	size_t n = block.getWidth() * block.getHeight();
-	for (size_t i = 0; i < n; i++) {
+	int n = block.getWidth() * block.getHeight();
+	for (int i = 0; i < n; i++) {
 		block.data[i] = rgba_multiply_scalar(block.data[i], factor);
 	}
 }
@@ -308,8 +308,8 @@ void blockImageTint(RGBAImage& block, const RGBAImage& mask, uint32_t color) {
 	assert(block.getWidth() == mask.getWidth());
 	assert(block.getHeight() == mask.getHeight());
 
-	size_t n = block.getWidth() * block.getHeight();
-	for (size_t i = 0; i < n; i++) {
+	int n = block.getWidth() * block.getHeight();
+	for (int i = 0; i < n; i++) {
 		uint32_t& pixel = block.data[i];
 		uint32_t mask_pixel = mask.data[i];
 		/*
@@ -328,8 +328,8 @@ void blockImageTint(RGBAImage& block, const RGBAImage& mask, uint32_t color) {
 }
 
 void blockImageTint(RGBAImage& block, uint32_t color) {
-	size_t n = block.getWidth() * block.getHeight();
-	for (size_t i = 0; i < n; i++) {
+	int n = block.getWidth() * block.getHeight();
+	for (int i = 0; i < n; i++) {
 		block.data[i] = rgba_multiply(block.data[i], color);
 	}
 }
@@ -479,8 +479,8 @@ bool blockImageIsTransparent(RGBAImage& block, const RGBAImage& uv_mask) {
 	assert(block.getWidth() == uv_mask.getWidth());
 	assert(block.getHeight() == uv_mask.getHeight());
 	
-	for (size_t x = 0; x < block.getWidth(); x++) {
-		for (size_t y = 0; y < block.getHeight(); y++) {
+	for (int x = 0; x < block.getWidth(); x++) {
+		for (int y = 0; y < block.getHeight(); y++) {
 			uint32_t& pixel = block.pixel(x, y);
 			uint32_t uv_pixel = uv_mask.pixel(x, y);
 			if (rgba_alpha(uv_pixel) == 0) {
@@ -499,8 +499,8 @@ bool blockImageIsTransparent(RGBAImage& block, const RGBAImage& uv_mask) {
 std::array<bool, 3> blockImageGetSideMask(const RGBAImage& uv) {
 	std::array<bool, 3> side_mask = {false, false, false};
 	uint8_t mask_indices[3] = {FACE_LEFT_INDEX, FACE_RIGHT_INDEX, FACE_UP_INDEX};
-	for (size_t x = 0; x < uv.getWidth(); x++) {
-		for (size_t y = 0; y < uv.getHeight(); y++) {
+	for (int x = 0; x < uv.getWidth(); x++) {
+		for (int y = 0; y < uv.getHeight(); y++) {
 			uint32_t pixel = uv.pixel(x, y);
 			if (rgba_alpha(pixel) == 0) {
 				continue;
@@ -682,8 +682,8 @@ bool RenderedBlockImages::loadBlockImages(fs::path path, std::string view, int r
 		if (block_info.count("shadow_edges")) {
 			block.shadow_edges = util::as<int>(block_info["shadow_edges"]);
 		}
-
-		if (block_images.size() < id + 1) {
+		uint16_t id_next = id + 1;
+		if (block_images.size() < id_next) {
 			block_images.resize(id + 1, nullptr);
 		}
 		block_images[id] = b;
@@ -735,7 +735,8 @@ RGBAImage RenderedBlockImages::exportBlocks() const {
 }
 
 const BlockImage& RenderedBlockImages::getBlockImage(uint16_t id) const {
-	if (block_images.size() < id + 1) {
+	uint16_t id_next = id + 1;
+	if (block_images.size() < id_next) {
 		const mc::BlockState& block_state = block_registry.getBlockState(id);
 		
 		if (!block_state.hasProperty("waterlogged")) {


### PR DESCRIPTION
I noticed when I was compiling from source there were a couple of signed/unsigned warnings caused by comparing if one type was less than/was greater than another in places such as for loops. This replaces a few uint types with regular signed ints and cleans up some of the output. Most of these integer types were originally initialized at 0 anyway so there wont be any likely negative-positive comparisons, and overflows are unlikely in these specific scenarios.

Most of these warnings stem down from image width and height being signed integers, I originally attempted to change them from int to uint and work my way up the warning ladder, but when compiling and running a sample map it resulted in blocks of map rendering wrong. In the future, it may be possible to properly implement width and height of images as uints, as from what I saw in the code there shouldn't be any reason for an image to have a "negative width/height" and it makes more sense for a picture to have unsigned dimensions (since a square cant have negative width/height).