### PR TITLE
cmake fix for RHEL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/mapcraftercore")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/test")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tools")


### PR DESCRIPTION
`make` was giving the following error with Oracle Linux, using gcc compiler 4.8. There might be a more desirable way to address this, but it seemed to work.

```
In file included from /usr/include/c++/4.8.2/condition_variable:35:0,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/../util/../compat/thread.h:29,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/../util/logging.h:23,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/../util.h:36,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/iniconfig.h:23,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/configparser.h:23,
                 from /home/opc/mapcrafter/src/mapcraftercore/config/configparser.cpp:20:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
```