### PR TITLE
fix slime overlay

### DIFF
--- a/src/mapcraftercore/mc/java.cpp
+++ b/src/mapcraftercore/mc/java.cpp
@@ -30,11 +30,11 @@ JavaRandom::~JavaRandom() {
 }
 
 void JavaRandom::setSeed(long long seed) {
-	this->seed = (seed ^ 0x5EECE66DLL) & ((1LL << 48) - 1);
+	this->seed = (seed ^ 0x5DEECE66DLL) & ((1LL << 48) - 1);
 }
 
 int JavaRandom::next(int bits) {
-	seed = (seed * 0x5EECE66DLL + 0xBLL) & ((1LL << 48) - 1);
+	seed = (seed * 0x5DEECE66DLL + 0xBLL) & ((1LL << 48) - 1);
 	return (int) (seed >> (48 - bits));
 }
 

--- a/src/mapcraftercore/renderer/rendermodes/slimeoverlay.cpp
+++ b/src/mapcraftercore/renderer/rendermodes/slimeoverlay.cpp
@@ -35,7 +35,8 @@ SlimeOverlay::SlimeOverlay(fs::path world_dir)
 		level_dat.readNBT((world_dir / "level.dat").string().c_str());
 
 		nbt::TagCompound data = level_dat.findTag<nbt::TagCompound>("Data");
-		nbt::TagLong random_seed = data.findTag<nbt::TagLong>("RandomSeed");
+		nbt::TagCompound worldGenSettings = data.findTag<nbt::TagCompound>("WorldGenSettings");
+		nbt::TagLong random_seed = worldGenSettings.findTag<nbt::TagLong>("seed");
 		world_seed = random_seed.payload;
 	} catch (nbt::NBTError& e) {
 		LOG(ERROR) << "Unable to read world seed from level.dat file for slime overlay: " << e.what();


### PR DESCRIPTION
The world seed has moved within the level.dat file.  This change lets Mapcrafter read the correct NBT tag for the world seed.  Fixes issue #16.

A constant/literal in the Java RNG was mistyped.  I've corrected it to align with the [official Java docs](https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#setSeed-long-).

With these two changes, slime overlay agrees with Chunkbase and in-game testing.