### PR TITLE
Experimental fix for chunks being offset for rotations other than top left

### DIFF
--- a/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.cpp
@@ -51,11 +51,11 @@ mc::ChunkPos TileTopBlockIterator::tile2Pos(int r, int c, const RenderRotation& 
 		case RenderRotation::TOP_LEFT:
 			return mc::ChunkPos((+c - r) / 2, (+c + r) / 2);
 		case RenderRotation::TOP_RIGHT:
-			return mc::ChunkPos((+c + r) / 2, (-c + r) / 2);
+			return mc::ChunkPos((+c + r) / 2, (-c + r) / 2 + 31);
 		case RenderRotation::BOTTOM_RIGHT:
-			return mc::ChunkPos((-c + r) / 2, (-c - r) / 2);
+			return mc::ChunkPos((-c + r) / 2 + 31, (-c - r) / 2 + 31);
 		case RenderRotation::BOTTOM_LEFT:
-			return mc::ChunkPos((-c - r) / 2, (+c - r) / 2);
+			return mc::ChunkPos((-c - r) / 2 + 31, (+c - r) / 2);
 	}
 }
 

--- a/src/mapcraftercore/renderer/renderviews/isometricnew/tileset.cpp
+++ b/src/mapcraftercore/renderer/renderviews/isometricnew/tileset.cpp
@@ -70,16 +70,16 @@ void NewIsometricTileSet::mapChunkToTiles(const mc::ChunkPos& chunk,
 			col = + chunk.x + chunk.z;
 			break;
 		case RenderRotation::TOP_RIGHT:
-			row = + chunk.x + chunk.z;
-			col = + chunk.x - chunk.z;
+			row = + chunk.x + (chunk.z - 31);
+			col = + chunk.x - (chunk.z - 31);
 			break;
 		case RenderRotation::BOTTOM_RIGHT:
-			row = + chunk.x - chunk.z;
-			col = - chunk.x - chunk.z;
+			row = + (chunk.x - 31) - (chunk.z - 31);
+			col = - (chunk.x - 31) - (chunk.z - 31);
 			break;
 		case RenderRotation::BOTTOM_LEFT:
-			row = - chunk.x - chunk.z;
-			col = - chunk.x + chunk.z;
+			row = - (chunk.x - 31) - chunk.z;
+			col = - (chunk.x - 31) + chunk.z;
 			break;
 	}
 


### PR DESCRIPTION
I noticed that the map coordinates and markers did not actually line up as intended with the world for all isometric rotations other than top left. These changes to the way tiles are mapped to chunks and vice versa seem to (mostly?) fix the issue, but I don't understand **why** it works - I just experimented with the math until the result looked better.

It's possible this "fix" is just a band-aid for a bug or problem somewhere else. I'm submitting this PR in the hope that it might still be usable or could help you figure out the real issue if it lies elsewhere. (I've only done some quick tests with 1.20 and haven't checked older versions.)