### PR TITLE
Fixed biome coloring for short_grass

### DIFF
--- a/src/data/blocks/isometric_0_12.txt
+++ b/src/data/blocks/isometric_0_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9728:9730:9732:9734,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9736:9738:9740:9742,is_waterloggable=true,uv=9737:9739:9741:9743
 minecraft:sea_pickle pickles=4,waterlogged=true color=9744:9746:9748:9750,is_waterloggable=true,uv=9745:9747:9749:9751
 minecraft:seagrass - color=9752,inherently_waterlogged=true,is_waterloggable=true,uv=9753
-minecraft:short_grass - color=4894,uv=4895
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4894,uv=4895
 minecraft:shroomlight - color=9754,uv=77
 minecraft:shulker_box facing=down color=9755,uv=77
 minecraft:shulker_box facing=east color=9756,uv=77

--- a/src/data/blocks/isometric_0_16.txt
+++ b/src/data/blocks/isometric_0_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9711:9713:9715:9717,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9719:9721:9723:9725,is_waterloggable=true,uv=9720:9722:9724:9726
 minecraft:sea_pickle pickles=4,waterlogged=true color=9727:9729:9731:9733,is_waterloggable=true,uv=9728:9730:9732:9734
 minecraft:seagrass - color=9735,inherently_waterlogged=true,is_waterloggable=true,uv=9736
-minecraft:short_grass - color=4882,uv=4883
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4882,uv=4883
 minecraft:shroomlight - color=9737,uv=77
 minecraft:shulker_box facing=down color=9738,uv=77
 minecraft:shulker_box facing=east color=9739,uv=77

--- a/src/data/blocks/isometric_1_12.txt
+++ b/src/data/blocks/isometric_1_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9807:9809:9811:9813,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9815:9817:9819:9821,is_waterloggable=true,uv=9816:9818:9820:9822
 minecraft:sea_pickle pickles=4,waterlogged=true color=9823:9825:9827:9829,is_waterloggable=true,uv=9824:9826:9828:9830
 minecraft:seagrass - color=9831,inherently_waterlogged=true,is_waterloggable=true,uv=9832
-minecraft:short_grass - color=4934,uv=4935
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4934,uv=4935
 minecraft:shroomlight - color=9833,uv=77
 minecraft:shulker_box facing=down color=9834,uv=77
 minecraft:shulker_box facing=east color=9835,uv=77

--- a/src/data/blocks/isometric_1_16.txt
+++ b/src/data/blocks/isometric_1_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9790:9792:9794:9796,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9798:9800:9802:9804,is_waterloggable=true,uv=9799:9801:9803:9805
 minecraft:sea_pickle pickles=4,waterlogged=true color=9806:9808:9810:9812,is_waterloggable=true,uv=9807:9809:9811:9813
 minecraft:seagrass - color=9814,inherently_waterlogged=true,is_waterloggable=true,uv=9815
-minecraft:short_grass - color=4922,uv=4923
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4922,uv=4923
 minecraft:shroomlight - color=9816,uv=77
 minecraft:shulker_box facing=down color=9817,uv=77
 minecraft:shulker_box facing=east color=9818,uv=77

--- a/src/data/blocks/isometric_2_12.txt
+++ b/src/data/blocks/isometric_2_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9797:9799:9801:9803,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9805:9807:9809:9811,is_waterloggable=true,uv=9806:9808:9810:9812
 minecraft:sea_pickle pickles=4,waterlogged=true color=9813:9815:9817:9819,is_waterloggable=true,uv=9814:9816:9818:9820
 minecraft:seagrass - color=9821,inherently_waterlogged=true,is_waterloggable=true,uv=9822
-minecraft:short_grass - color=4922,uv=4923
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4922,uv=4923
 minecraft:shroomlight - color=9823,uv=77
 minecraft:shulker_box facing=down color=9824,uv=77
 minecraft:shulker_box facing=east color=9825,uv=77

--- a/src/data/blocks/isometric_2_16.txt
+++ b/src/data/blocks/isometric_2_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9792:9794:9796:9798,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9800:9802:9804:9806,is_waterloggable=true,uv=9801:9803:9805:9807
 minecraft:sea_pickle pickles=4,waterlogged=true color=9808:9810:9812:9814,is_waterloggable=true,uv=9809:9811:9813:9815
 minecraft:seagrass - color=9816,inherently_waterlogged=true,is_waterloggable=true,uv=9817
-minecraft:short_grass - color=4922,uv=4923
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4922,uv=4923
 minecraft:shroomlight - color=9818,uv=77
 minecraft:shulker_box facing=down color=9819,uv=77
 minecraft:shulker_box facing=east color=9820,uv=77

--- a/src/data/blocks/isometric_3_12.txt
+++ b/src/data/blocks/isometric_3_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9797:9799:9801:9803,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9805:9807:9809:9811,is_waterloggable=true,uv=9806:9808:9810:9812
 minecraft:sea_pickle pickles=4,waterlogged=true color=9813:9815:9817:9819,is_waterloggable=true,uv=9814:9816:9818:9820
 minecraft:seagrass - color=9821,inherently_waterlogged=true,is_waterloggable=true,uv=9822
-minecraft:short_grass - color=4922,uv=4923
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4922,uv=4923
 minecraft:shroomlight - color=9823,uv=77
 minecraft:shulker_box facing=down color=9824,uv=77
 minecraft:shulker_box facing=east color=9825,uv=77

--- a/src/data/blocks/isometric_3_16.txt
+++ b/src/data/blocks/isometric_3_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9792:9794:9796:9798,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9800:9802:9804:9806,is_waterloggable=true,uv=9801:9803:9805:9807
 minecraft:sea_pickle pickles=4,waterlogged=true color=9808:9810:9812:9814,is_waterloggable=true,uv=9809:9811:9813:9815
 minecraft:seagrass - color=9816,inherently_waterlogged=true,is_waterloggable=true,uv=9817
-minecraft:short_grass - color=4922,uv=4923
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4922,uv=4923
 minecraft:shroomlight - color=9818,uv=77
 minecraft:shulker_box facing=down color=9819,uv=77
 minecraft:shulker_box facing=east color=9820,uv=77

--- a/src/data/blocks/side_0_12.txt
+++ b/src/data/blocks/side_0_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=8941:8943:8945:8947,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=8949:8951:8953:8955,is_waterloggable=true,uv=8950:8952:8954:8956
 minecraft:sea_pickle pickles=4,waterlogged=true color=8957:8959:8961:8963,is_waterloggable=true,uv=8958:8960:8962:8964
 minecraft:seagrass - color=8965,inherently_waterlogged=true,is_waterloggable=true,uv=8966
-minecraft:short_grass - color=4483,uv=4484
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4483,uv=4484
 minecraft:shroomlight - color=8967,uv=70
 minecraft:shulker_box facing=down color=8968,uv=70
 minecraft:shulker_box facing=east color=8969,uv=70

--- a/src/data/blocks/side_0_16.txt
+++ b/src/data/blocks/side_0_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=8954:8956:8958:8960,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=8962:8964:8966:8968,is_waterloggable=true,uv=8963:8965:8967:8969
 minecraft:sea_pickle pickles=4,waterlogged=true color=8970:8972:8974:8976,is_waterloggable=true,uv=8971:8973:8975:8977
 minecraft:seagrass - color=8978,inherently_waterlogged=true,is_waterloggable=true,uv=8979
-minecraft:short_grass - color=4487,uv=4488
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4487,uv=4488
 minecraft:shroomlight - color=8980,uv=71
 minecraft:shulker_box facing=down color=8981,uv=71
 minecraft:shulker_box facing=east color=8982,uv=71

--- a/src/data/blocks/side_1_12.txt
+++ b/src/data/blocks/side_1_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9014:9016:9018:9020,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9022:9024:9026:9028,is_waterloggable=true,uv=9023:9025:9027:9029
 minecraft:sea_pickle pickles=4,waterlogged=true color=9030:9032:9034:9036,is_waterloggable=true,uv=9031:9033:9035:9037
 minecraft:seagrass - color=9038,inherently_waterlogged=true,is_waterloggable=true,uv=9039
-minecraft:short_grass - color=4516,uv=4517
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4516,uv=4517
 minecraft:shroomlight - color=9040,uv=70
 minecraft:shulker_box facing=down color=9041,uv=70
 minecraft:shulker_box facing=east color=9042,uv=70

--- a/src/data/blocks/side_1_16.txt
+++ b/src/data/blocks/side_1_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9025:9027:9029:9031,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9033:9035:9037:9039,is_waterloggable=true,uv=9034:9036:9038:9040
 minecraft:sea_pickle pickles=4,waterlogged=true color=9041:9043:9045:9047,is_waterloggable=true,uv=9042:9044:9046:9048
 minecraft:seagrass - color=9049,inherently_waterlogged=true,is_waterloggable=true,uv=9050
-minecraft:short_grass - color=4519,uv=4520
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4519,uv=4520
 minecraft:shroomlight - color=9051,uv=71
 minecraft:shulker_box facing=down color=9052,uv=71
 minecraft:shulker_box facing=east color=9053,uv=71

--- a/src/data/blocks/side_2_12.txt
+++ b/src/data/blocks/side_2_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9024:9026:9028:9030,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9032:9034:9036:9038,is_waterloggable=true,uv=9033:9035:9037:9039
 minecraft:sea_pickle pickles=4,waterlogged=true color=9040:9042:9044:9046,is_waterloggable=true,uv=9041:9043:9045:9047
 minecraft:seagrass - color=9048,inherently_waterlogged=true,is_waterloggable=true,uv=9049
-minecraft:short_grass - color=4517,uv=4518
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4517,uv=4518
 minecraft:shroomlight - color=9050,uv=70
 minecraft:shulker_box facing=down color=9051,uv=70
 minecraft:shulker_box facing=east color=9052,uv=70

--- a/src/data/blocks/side_2_16.txt
+++ b/src/data/blocks/side_2_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9037:9039:9041:9043,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9045:9047:9049:9051,is_waterloggable=true,uv=9046:9048:9050:9052
 minecraft:sea_pickle pickles=4,waterlogged=true color=9053:9055:9057:9059,is_waterloggable=true,uv=9054:9056:9058:9060
 minecraft:seagrass - color=9061,inherently_waterlogged=true,is_waterloggable=true,uv=9062
-minecraft:short_grass - color=4528,uv=4529
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4528,uv=4529
 minecraft:shroomlight - color=9063,uv=71
 minecraft:shulker_box facing=down color=9064,uv=71
 minecraft:shulker_box facing=east color=9065,uv=71

--- a/src/data/blocks/side_3_12.txt
+++ b/src/data/blocks/side_3_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9022:9024:9026:9028,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9030:9032:9034:9036,is_waterloggable=true,uv=9031:9033:9035:9037
 minecraft:sea_pickle pickles=4,waterlogged=true color=9038:9040:9042:9044,is_waterloggable=true,uv=9039:9041:9043:9045
 minecraft:seagrass - color=9046,inherently_waterlogged=true,is_waterloggable=true,uv=9047
-minecraft:short_grass - color=4517,uv=4518
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4517,uv=4518
 minecraft:shroomlight - color=9048,uv=70
 minecraft:shulker_box facing=down color=9049,uv=70
 minecraft:shulker_box facing=east color=9050,uv=70

--- a/src/data/blocks/side_3_16.txt
+++ b/src/data/blocks/side_3_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=9027:9029:9031:9033,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=9035:9037:9039:9041,is_waterloggable=true,uv=9036:9038:9040:9042
 minecraft:sea_pickle pickles=4,waterlogged=true color=9043:9045:9047:9049,is_waterloggable=true,uv=9044:9046:9048:9050
 minecraft:seagrass - color=9051,inherently_waterlogged=true,is_waterloggable=true,uv=9052
-minecraft:short_grass - color=4520,uv=4521
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=4520,uv=4521
 minecraft:shroomlight - color=9053,uv=71
 minecraft:shulker_box facing=down color=9054,uv=71
 minecraft:shulker_box facing=east color=9055,uv=71

--- a/src/data/blocks/topdown_0_12.txt
+++ b/src/data/blocks/topdown_0_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4105:4107:4109:4111,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4113:4115:4117:4119,is_waterloggable=true,uv=4114:4116:4118:4120
 minecraft:sea_pickle pickles=4,waterlogged=true color=4113:4115:4117:4119,is_waterloggable=true,uv=4114:4116:4118:4120
 minecraft:seagrass - color=24,inherently_waterlogged=true,is_waterloggable=true,uv=24
-minecraft:short_grass - color=24,uv=24
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=24,uv=24
 minecraft:shroomlight - color=4121,uv=46
 minecraft:shulker_box facing=down color=4122,uv=46
 minecraft:shulker_box facing=east color=4123,uv=46

--- a/src/data/blocks/topdown_0_16.txt
+++ b/src/data/blocks/topdown_0_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4111:4113:4115:4117,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4119:4121:4123:4125,is_waterloggable=true,uv=4120:4122:4124:4126
 minecraft:sea_pickle pickles=4,waterlogged=true color=4119:4121:4123:4125,is_waterloggable=true,uv=4120:4122:4124:4126
 minecraft:seagrass - color=26,inherently_waterlogged=true,is_waterloggable=true,uv=26
-minecraft:short_grass - color=26,uv=26
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=26,uv=26
 minecraft:shroomlight - color=4127,uv=48
 minecraft:shulker_box facing=down color=4128,uv=48
 minecraft:shulker_box facing=east color=4129,uv=48

--- a/src/data/blocks/topdown_1_12.txt
+++ b/src/data/blocks/topdown_1_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4323:4325:4327:4329,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4331:4333:4335:4337,is_waterloggable=true,uv=4332:4334:4336:4338
 minecraft:sea_pickle pickles=4,waterlogged=true color=4331:4333:4335:4337,is_waterloggable=true,uv=4332:4334:4336:4338
 minecraft:seagrass - color=24,inherently_waterlogged=true,is_waterloggable=true,uv=24
-minecraft:short_grass - color=24,uv=24
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=24,uv=24
 minecraft:shroomlight - color=4339,uv=46
 minecraft:shulker_box facing=down color=4340,uv=46
 minecraft:shulker_box facing=east color=4341,uv=46

--- a/src/data/blocks/topdown_1_16.txt
+++ b/src/data/blocks/topdown_1_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4329:4331:4333:4335,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4337:4339:4341:4343,is_waterloggable=true,uv=4338:4340:4342:4344
 minecraft:sea_pickle pickles=4,waterlogged=true color=4337:4339:4341:4343,is_waterloggable=true,uv=4338:4340:4342:4344
 minecraft:seagrass - color=26,inherently_waterlogged=true,is_waterloggable=true,uv=26
-minecraft:short_grass - color=26,uv=26
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=26,uv=26
 minecraft:shroomlight - color=4345,uv=48
 minecraft:shulker_box facing=down color=4346,uv=48
 minecraft:shulker_box facing=east color=4347,uv=48

--- a/src/data/blocks/topdown_2_12.txt
+++ b/src/data/blocks/topdown_2_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4984:4986:4988:4990,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4992:4994:4996:4998,is_waterloggable=true,uv=4993:4995:4997:4999
 minecraft:sea_pickle pickles=4,waterlogged=true color=4992:4994:4996:4998,is_waterloggable=true,uv=4993:4995:4997:4999
 minecraft:seagrass - color=24,inherently_waterlogged=true,is_waterloggable=true,uv=24
-minecraft:short_grass - color=24,uv=24
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=24,uv=24
 minecraft:shroomlight - color=5000,uv=46
 minecraft:shulker_box facing=down color=5001,uv=46
 minecraft:shulker_box facing=east color=5002,uv=46

--- a/src/data/blocks/topdown_2_16.txt
+++ b/src/data/blocks/topdown_2_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4989:4991:4993:4995,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4997:4999:5001:5003,is_waterloggable=true,uv=4998:5000:5002:5004
 minecraft:sea_pickle pickles=4,waterlogged=true color=4997:4999:5001:5003,is_waterloggable=true,uv=4998:5000:5002:5004
 minecraft:seagrass - color=26,inherently_waterlogged=true,is_waterloggable=true,uv=26
-minecraft:short_grass - color=26,uv=26
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=26,uv=26
 minecraft:shroomlight - color=5005,uv=48
 minecraft:shulker_box facing=down color=5006,uv=48
 minecraft:shulker_box facing=east color=5007,uv=48

--- a/src/data/blocks/topdown_3_12.txt
+++ b/src/data/blocks/topdown_3_12.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4588:4590:4592:4594,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4596:4598:4600:4602,is_waterloggable=true,uv=4597:4599:4601:4603
 minecraft:sea_pickle pickles=4,waterlogged=true color=4596:4598:4600:4602,is_waterloggable=true,uv=4597:4599:4601:4603
 minecraft:seagrass - color=24,inherently_waterlogged=true,is_waterloggable=true,uv=24
-minecraft:short_grass - color=24,uv=24
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=24,uv=24
 minecraft:shroomlight - color=4604,uv=46
 minecraft:shulker_box facing=down color=4605,uv=46
 minecraft:shulker_box facing=east color=4606,uv=46

--- a/src/data/blocks/topdown_3_16.txt
+++ b/src/data/blocks/topdown_3_16.txt
@@ -10058,7 +10058,7 @@ minecraft:sea_pickle pickles=3,waterlogged=true color=4593:4595:4597:4599,is_wat
 minecraft:sea_pickle pickles=4,waterlogged=false color=4601:4603:4605:4607,is_waterloggable=true,uv=4602:4604:4606:4608
 minecraft:sea_pickle pickles=4,waterlogged=true color=4601:4603:4605:4607,is_waterloggable=true,uv=4602:4604:4606:4608
 minecraft:seagrass - color=26,inherently_waterlogged=true,is_waterloggable=true,uv=26
-minecraft:short_grass - color=26,uv=26
+minecraft:short_grass - biome_colormap=#ff55b7be|#ff96b481|#ff33cd49,biome_colors=grass,biome_type=simple,color=26,uv=26
 minecraft:shroomlight - color=4609,uv=48
 minecraft:shulker_box facing=down color=4610,uv=48
 minecraft:shulker_box facing=east color=4611,uv=48


### PR DESCRIPTION
My short grass started rendering gray, I think because the block ID of `minecraft:grass` changed to `minecraft:short_grass` in 1.20.3:

![image](https://github.com/miclav/mapcrafter/assets/2257726/d2a34444-e0cb-4ad4-91ea-5efc4917c101)

It looks like you started adding support for `short_grass`, but the block info txt files in src/data/blocks was missing the biome coloring info. Not sure if you're already working on an update to blockcrafter to fix this properly, but I manually edited the txt files to add the biome stuff (copying from the original `grass`) and it seems to work. Here are my changes in case you want to go ahead and merge them in.