### PR TITLE
Optimize TileRenderer tile image sorting

### DIFF
--- a/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.cpp
@@ -183,7 +183,7 @@ int NewIsometricTileRenderer::getTileSize() const {
 	return images->getBlockSize() * 16 * tile_width;
 }
 
-void NewIsometricTileRenderer::renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images) {
+void NewIsometricTileRenderer::renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images) {
 	int block_size = images->getBlockSize();
 	mc::BlockDir dir = render_view->getRotation().rotate(mc::DIR_NORTH + mc::DIR_EAST + mc::DIR_BOTTOM);
 	for (old::TileTopBlockIterator it(tile_pos, block_size, tile_width, render_view); !it.end(); it.next()) {

--- a/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.h
+++ b/src/mapcraftercore/renderer/renderviews/isometricnew/tilerenderer.h
@@ -90,7 +90,7 @@ public:
 	virtual int getTileSize() const;
 
 protected:
-	virtual void renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images);
+	virtual void renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images);
 };
 
 }

--- a/src/mapcraftercore/renderer/renderviews/side/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/renderviews/side/tilerenderer.cpp
@@ -63,7 +63,7 @@ int SideTileRenderer::getTileHeight() const {
 	return block_images->getBlockHeight() * 8 * tile_width;
 }
 
-void SideTileRenderer::renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images) {
+void SideTileRenderer::renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images) {
 	int block_width = block_images->getBlockWidth();
 	int block_height = block_images->getBlockHeight();
 	for (int cx = 0; cx < tile_width; cx++) {

--- a/src/mapcraftercore/renderer/renderviews/side/tilerenderer.h
+++ b/src/mapcraftercore/renderer/renderviews/side/tilerenderer.h
@@ -40,7 +40,7 @@ public:
 	virtual int getTileHeight() const;
 
 protected:
-	virtual void renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images);
+	virtual void renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images);
 };
 
 }

--- a/src/mapcraftercore/renderer/renderviews/topdown/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/renderviews/topdown/tilerenderer.cpp
@@ -53,7 +53,7 @@ int TopdownTileRenderer::getTileSize() const {
 	return images->getBlockSize() * 16 * tile_width;
 }
 
-void TopdownTileRenderer::renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images) {
+void TopdownTileRenderer::renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images) {
 	int block_size = images->getBlockSize();
 	for (int cx = 0; cx < tile_width; cx++) {
 		for (int cz = 0; cz < tile_width; cz++) {

--- a/src/mapcraftercore/renderer/renderviews/topdown/tilerenderer.h
+++ b/src/mapcraftercore/renderer/renderviews/topdown/tilerenderer.h
@@ -38,7 +38,7 @@ public:
 	virtual int getTileSize() const;
 
 protected:
-	virtual void renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images);
+	virtual void renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images);
 };
 
 }

--- a/src/mapcraftercore/renderer/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/tilerenderer.cpp
@@ -121,7 +121,7 @@ void TileRenderer::renderTile(const TilePos& tile_pos, RGBAImage& tile) {
 
 	size_t tile_images_capacity_value = tile_images_maxsize;
 
-	boost::container::vector<TileImage> tile_images;
+	std::vector<TileImage> tile_images;
     tile_images.reserve(tile_images_capacity_value * 2);
 	renderTopBlocks(tile_pos, tile_images);
 
@@ -152,7 +152,7 @@ int TileRenderer::getTileHeight() const {
 	return getTileSize();
 }
 
-void TileRenderer::renderBlocks(int x, int y, mc::BlockPos top, const mc::BlockDir& dir, boost::container::vector<TileImage>& tile_images) {
+void TileRenderer::renderBlocks(int x, int y, mc::BlockPos top, const mc::BlockDir& dir, std::vector<TileImage>& tile_images) {
 
 	for (; top.y >= mc::CHUNK_LOWEST*16 ; top += dir) {
 		// get current chunk position

--- a/src/mapcraftercore/renderer/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/tilerenderer.cpp
@@ -19,7 +19,8 @@
 
 #include "tilerenderer.h"
 
-#include <boost/range/algorithm/sort.hpp>
+#include <algorithm> //std::sort()
+#include <vector>
 
 #include "blockimages.h"
 #include "rendermode.h"
@@ -65,48 +66,49 @@ void TileRenderer::setShadowEdges(std::array<uint8_t, 5> shadow_edges) {
 	this->shadow_edges = shadow_edges;
 }
 
-TileRenderer::cmpBlockPos* TileRenderer::getTileComparator() const {
-	switch ((RenderRotation::Direction)render_view->getRotation()){
+template<typename IT>
+static void sortTiles(IT begin, IT end, RenderRotation::Direction dir) {
+	switch (dir){
 	default:
 	case RenderRotation::TOP_LEFT:
-		return [](const TileImage& a, const TileImage& b) -> bool {
+		std::sort(begin, end, [](const TileImage* a, const TileImage* b) -> bool {
 			return
-				(a.pos.y != b.pos.y) ? (a.pos.y < b.pos.y) : (
-				(a.pos.z != b.pos.z) ? (a.pos.z < b.pos.z) : (
-				(a.pos.x != b.pos.x) ? (a.pos.x > b.pos.x) : (
+				(a->pos.y != b->pos.y) ? (a->pos.y < b->pos.y) : (
+				(a->pos.z != b->pos.z) ? (a->pos.z < b->pos.z) : (
+				(a->pos.x != b->pos.x) ? (a->pos.x > b->pos.x) : (
 					false
 				)));
-		};
+		});
 		break;
 	case RenderRotation::TOP_RIGHT:
-		return [](const TileImage& a, const TileImage& b) -> bool {
+		std::sort(begin, end, [](const TileImage* a, const TileImage* b) -> bool {
 			return
-				(a.pos.y != b.pos.y) ? (a.pos.y < b.pos.y) : (
-				(a.pos.x != b.pos.x) ? (a.pos.x < b.pos.x) : (
-				(a.pos.z != b.pos.z) ? (a.pos.z < b.pos.z) : (
+				(a->pos.y != b->pos.y) ? (a->pos.y < b->pos.y) : (
+				(a->pos.x != b->pos.x) ? (a->pos.x < b->pos.x) : (
+				(a->pos.z != b->pos.z) ? (a->pos.z < b->pos.z) : (
 					false
 				)));
-		};
+		});
 		break;
 	case RenderRotation::BOTTOM_RIGHT:
-		return [](const TileImage& a, const TileImage& b) -> bool {
+		std::sort(begin, end, [](const TileImage* a, const TileImage* b) -> bool {
 			return
-				(a.pos.y != b.pos.y) ? (a.pos.y < b.pos.y) : (
-				(a.pos.z != b.pos.z) ? (a.pos.z > b.pos.z) : (
-				(a.pos.x != b.pos.x) ? (a.pos.x < b.pos.x) : (
+				(a->pos.y != b->pos.y) ? (a->pos.y < b->pos.y) : (
+				(a->pos.z != b->pos.z) ? (a->pos.z > b->pos.z) : (
+				(a->pos.x != b->pos.x) ? (a->pos.x < b->pos.x) : (
 					false
 				)));
-		};
+		});
 		break;
 	case RenderRotation::BOTTOM_LEFT:
-		return [](const TileImage& a, const TileImage& b) -> bool {
+		std::sort(begin, end, [](const TileImage* a, const TileImage* b) -> bool {
 			return
-				(a.pos.y != b.pos.y) ? (a.pos.y < b.pos.y) : (
-				(a.pos.x != b.pos.x) ? (a.pos.x > b.pos.x) : (
-				(a.pos.z != b.pos.z) ? (a.pos.z > b.pos.z) : (
+				(a->pos.y != b->pos.y) ? (a->pos.y < b->pos.y) : (
+				(a->pos.x != b->pos.x) ? (a->pos.x > b->pos.x) : (
+				(a->pos.z != b->pos.z) ? (a->pos.z > b->pos.z) : (
 					false
 				)));
-		};
+		});
 		break;
 	}
 }
@@ -117,10 +119,16 @@ void TileRenderer::renderTile(const TilePos& tile_pos, RGBAImage& tile) {
 	boost::container::vector<TileImage> tile_images;
 	renderTopBlocks(tile_pos, tile_images);
 
-	// Sort them in order depending of the rotation
-	boost::range::sort(tile_images, getTileComparator());
+    size_t count = tile_images.size();
+    std::vector<TileImage*> tile_image_pointers(count);
+    for (size_t i = 0; i < count; i++) {
+        tile_image_pointers[i] = &tile_images[i];
+    }
 
-	for (auto it = tile_images.begin(); it != tile_images.end(); ++it) {
+	// Sort them in order depending of the rotation
+	sortTiles(tile_image_pointers.begin(), tile_image_pointers.end(), (RenderRotation::Direction)render_view->getRotation());
+
+	for (auto it : tile_image_pointers) {
 		tile.alphaBlit(it->image, it->x, it->y);
 	}
 }

--- a/src/mapcraftercore/renderer/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/tilerenderer.cpp
@@ -20,6 +20,7 @@
 #include "tilerenderer.h"
 
 #include <algorithm> //std::sort()
+#include <atomic>
 #include <vector>
 
 #include "blockimages.h"
@@ -114,12 +115,22 @@ static void sortTiles(IT begin, IT end, RenderRotation::Direction dir) {
 }
 
 void TileRenderer::renderTile(const TilePos& tile_pos, RGBAImage& tile) {
+	static std::atomic<size_t> tile_images_maxsize(64 << 10); //64Ki
+
 	tile.setSize(getTileWidth(), getTileHeight());
 
+	size_t tile_images_capacity_value = tile_images_maxsize;
+
 	boost::container::vector<TileImage> tile_images;
+    tile_images.reserve(tile_images_capacity_value * 2);
 	renderTopBlocks(tile_pos, tile_images);
 
-    size_t count = tile_images.size();
+	size_t count = tile_images.size();
+	if (count > tile_images_capacity_value
+	    && tile_images_maxsize.compare_exchange_strong(tile_images_capacity_value, count)) {
+		LOG(DEBUG) << "raised initial tile_images capacity to " << count;
+	}
+
     std::vector<TileImage*> tile_image_pointers(count);
     for (size_t i = 0; i < count; i++) {
         tile_image_pointers[i] = &tile_images[i];

--- a/src/mapcraftercore/renderer/tilerenderer.cpp
+++ b/src/mapcraftercore/renderer/tilerenderer.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm> //std::sort()
 #include <atomic>
+#include <memory> // std::allocator
 #include <vector>
 
 #include "blockimages.h"
@@ -31,6 +32,8 @@
 #include "../mc/blockstate.h"
 #include "../mc/pos.h"
 #include "../util.h"
+
+#include <boost/core/noinit_adaptor.hpp>
 
 namespace mapcrafter {
 namespace renderer {
@@ -131,10 +134,13 @@ void TileRenderer::renderTile(const TilePos& tile_pos, RGBAImage& tile) {
 		LOG(DEBUG) << "raised initial tile_images capacity to " << count;
 	}
 
-    std::vector<TileImage*> tile_image_pointers(count);
-    for (size_t i = 0; i < count; i++) {
-        tile_image_pointers[i] = &tile_images[i];
-    }
+	//get pointers to all the TileImages
+	std::vector<TileImage*, boost::noinit_adaptor<std::allocator<TileImage*>>> tile_image_pointers(count);
+	std::transform(
+			tile_images.begin(), tile_images.end(), tile_image_pointers.begin(),
+			[](TileImage& tile_image) -> TileImage* {
+				return &tile_image;
+			});
 
 	// Sort them in order depending of the rotation
 	sortTiles(tile_image_pointers.begin(), tile_image_pointers.end(), (RenderRotation::Direction)render_view->getRotation());

--- a/src/mapcraftercore/renderer/tilerenderer.h
+++ b/src/mapcraftercore/renderer/tilerenderer.h
@@ -52,7 +52,6 @@ struct TileImage {
 	int x, y;
 	RGBAImage image;
 	mc::BlockPos pos;
-	int z_index;
 
 	TileImage() {}
 	TileImage(int width, int height): image(width, height) {}

--- a/src/mapcraftercore/renderer/tilerenderer.h
+++ b/src/mapcraftercore/renderer/tilerenderer.h
@@ -75,9 +75,6 @@ public:
 	virtual int getTileHeight() const;
 
 protected:
-	// void sortTiles(boost::container::vector<TileImage>& tile_images) const;
-	typedef bool cmpBlockPos(const TileImage &, const TileImage &);
-	cmpBlockPos* getTileComparator() const;
 	void renderBlocks(int x, int y, mc::BlockPos top, const mc::BlockDir& dir, boost::container::vector<TileImage>& tile_images);
 	virtual void renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images) {}
 

--- a/src/mapcraftercore/renderer/tilerenderer.h
+++ b/src/mapcraftercore/renderer/tilerenderer.h
@@ -27,7 +27,6 @@
 #include <array>
 #include <vector>
 #include <boost/filesystem.hpp>
-#include <boost/container/vector.hpp>
 
 namespace fs = boost::filesystem;
 
@@ -75,8 +74,8 @@ public:
 	virtual int getTileHeight() const;
 
 protected:
-	void renderBlocks(int x, int y, mc::BlockPos top, const mc::BlockDir& dir, boost::container::vector<TileImage>& tile_images);
-	virtual void renderTopBlocks(const TilePos& tile_pos, boost::container::vector<TileImage>& tile_images) {}
+	void renderBlocks(int x, int y, mc::BlockPos top, const mc::BlockDir& dir, std::vector<TileImage>& tile_images);
+	virtual void renderTopBlocks(const TilePos& tile_pos, std::vector<TileImage>& tile_images) {}
 
 	mc::Block getBlock(const mc::BlockPos& pos, int get = mc::GET_ID);
 	uint32_t getBiomeColor(const mc::BlockPos& pos, const BlockImage& block, const mc::Chunk* chunk);


### PR DESCRIPTION
This contains three main changes:
- Instead of sorting `TileImage`s directly, we'll leave them unmodified and sort pointers to them instead. This makes the actual sorting much faster, since it only has to swap a pair of pointers after each comparison instead of a 56-byte class with a non-trivial move assignment operator.
- `std::sort()` is now invoked separately for each of the sort modes, allowing the comparator to be inlined into the sorting code
- Originally, a lot of time was being wasted resizing the `tile_images` vector when filling it. This mitigates that by reserving a generous amount of space ahead of time, and also keeps track of the global maximum number of images per tile encountered so far.

These three optimizations reduce the total render time of a simple map by ~15% on my machine.

I've also replaced `boost::container::vector` with `std::vector` just to shave off an `#include`.